### PR TITLE
Fix path to github archives.

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,12 +35,13 @@ function download(repo, dest, fn){
  */
 
 function github(repo){
-  return 'https://codeload.github.com/'
+  return 'https://github.com/'
     + repo.owner
     + '/'
     + repo.name
-    + '/legacy.tar.gz/'
-    + repo.branch;
+    + '/archive/'
+    + repo.branch
+    + '.zip';
 }
 
 /**


### PR DESCRIPTION
I was receiving 400 Invalid Request with the existing path.  Seems github has deprecated the existing url structure:
http://stackoverflow.com/questions/2751227/how-to-download-source-in-zip-format-from-github

Tests were failing to confirm my results.  This seems to fix it.
