### PR TITLE
Use ES6 Promises

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,29 +1,55 @@
 var wget = require('download');
+var request = require('request-promise');
 
 /**
  * Expose `download`.
  */
 
-module.exports = download;
+module.exports = { download: download, query: query };
 
 /**
- * Download GitHub `repo` to `dest` and callback `fn(err)`.
+ * Query GitHub `repo` for commit hash.
+ *
+ * @param {String} repo
+ * @return {Promise} Returns commit hash.
+ */
+
+function query(repo) {
+  return new Promise((resolve, reject) => {
+    var url = api(normalize(repo));
+    request({ uri: url, json: true, headers: { 'User-Agent': 'Request-Promise'} })
+      .then(json => {
+        resolve(json.sha);
+      })
+      .catch(err => {
+        reject(err);
+      });
+  });
+}
+
+
+/**
+ * Download GitHub `repo` to `dest`
  *
  * @param {String} repo
  * @param {String} dest
- * @param {Function} fn
+ * @return {Promise} Returns commit hash.
  */
 
-function download(repo, dest, fn){
-  var url = github(normalize(repo));
-  var dl = wget(url, dest, { extract: true, strip: 1 });
+function download(repo, dest) {
+  console.log("downloading", repo, dest);
+  return new Promise((resolve, reject) => {
+    query(repo).then(commit => {
 
-  dl.on('error', function(err){
-    fn(err);
-  });
+      repo = normalize(repo);
+      repo.commit = commit;
+      var url = github(repo);
+      var dl = wget(url, dest, { extract: true, strip: 1 });
 
-  dl.on('close', function(){
-    fn();
+      dl.on('error', () => { reject; } );
+      dl.on('close', () => { resolve(commit); } );
+
+    }).catch(reject);
   });
 }
 
@@ -40,8 +66,24 @@ function github(repo){
     + '/'
     + repo.name
     + '/archive/'
-    + repo.branch
+    + (repo.commit || "master")
     + '.zip';
+}
+
+/**
+ * Return a GitHub API url for a given `repo` object.
+ *
+ * @param {Object} repo
+ * @return {String}
+ */
+
+function api(repo){
+  return 'https://api.github.com/repos/'
+    + repo.owner
+    + '/'
+    + repo.name
+    + '/commits/'
+    + repo.branch;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "download-github-repo",
-  "version": "0.1.3",
+  "version": "1.0.0",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/download-github-repo",
   "description": "Download and extract a GitHub repository from node.",
@@ -14,13 +14,15 @@
     "tarball"
   ],
   "dependencies": {
-    "download": "^0.1.11"
+    "download": "^0.1.11",
+    "request-promise": "^2.0.1"
   },
   "devDependencies": {
     "mocha": "~1.17.1",
     "fs-readdir-recursive": "0.0.1",
     "rimraf": "~2.2.6"
   },
+  "engines" : { "node" : ">=4.0.0" },
   "scripts": {
     "test": "mocha"
   }

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,6 @@
 
 var assert = require('assert');
-var download = require('..');
+var repo = require('..');
 var read = require('fs-readdir-recursive');
 var rm = require('rimraf').sync;
 
@@ -10,23 +10,50 @@ describe('download-github-repo', function(){
   });
 
   it('downloads the master branch by default', function(done){
-    download('zeke/download-github-repo-fixture', 'test/tmp', function(err){
-      if (err) return done(err);
+    repo.download('zeke/download-github-repo-fixture', 'test/tmp').then((hash) => {
       var actual = read('test/tmp');
       var expected = read('test/fixtures/master');
       assert.deepEqual(actual, expected);
+      assert.equal(hash, 'ff95faeda055a8061fe45742a46f80b39c633ddd');
       done();
+    })
+    .catch(err => {
+      return done(err);
     });
   });
 
-  it('download branches too', function(done){
-    download('zeke/download-github-repo-fixture#my-branch', 'test/tmp', function(err){
-      if (err) return done(err);
+  it('download custom branch', function(done){
+    repo.download('zeke/download-github-repo-fixture#my-branch', 'test/tmp').then((hash) => {
       var actual = read('test/tmp');
       var expected = read('test/fixtures/my-branch');
       assert.deepEqual(actual, expected);
+      assert.equal(hash, '619f72b64bf3bc9457e4b578373eb675481d2ff5');
       done();
+    })
+    .catch(err => {
+      return done(err);
     });
   });
+
+  it('queries master branch commit', function(done){
+    repo.query('zeke/download-github-repo-fixture').then((hash) => {
+      assert.equal(hash, 'ff95faeda055a8061fe45742a46f80b39c633ddd');
+      done();
+    })
+    .catch(err => {
+      return done(err);
+    });
+  });
+
+  it('queries custom branch commit', function(done){
+    repo.query('zeke/download-github-repo-fixture#my-branch').then((hash) => {
+      assert.equal(hash, '619f72b64bf3bc9457e4b578373eb675481d2ff5');
+      done();
+    })
+    .catch(err => {
+      return done(err);
+    });
+  });
+
 
 });


### PR DESCRIPTION
**This is a BREAKING CHANGE**

Considering that I had to break the `module.exports` to export `query()`, I felt it warranted a version bump per [semver](http://www.semver.org) rules.  SINCE I was already version bumping (and thus breaking), I felt that using ES6 notation (including Promises and Arrow Notation) was not out of line.

1. `module.exports` now exports an object of functions rather than just the download function.
2. This uses ES6 notation, and only works on v4.0+

Changes:

* Uses Promises for larger repos!
* Returns commit hash of repo downloaded so you can always be sure which version you have.
* Expose `query()` for parent application update-checking.