### PR TITLE
upgrade to download@6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "download-github-repo",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/download-github-repo",
   "description": "Download and extract a GitHub repository from node.",
@@ -14,7 +14,7 @@
     "tarball"
   ],
   "dependencies": {
-    "download": "^0.1.11"
+    "download": "^0.6.0"
   },
   "devDependencies": {
     "mocha": "~1.17.1",


### PR DESCRIPTION
Old versions of `download` had dependencies that posed a security threat (specifically involving `tar`). Upgrading to the latest version should remove the threat.

More info:
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-8860
